### PR TITLE
Code reformatting

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: droppedbars
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=D7J2RY6828E7N
 Tags: import,HTML,website,webpage,flare,xml
 Requires at least: 3.8.1
-Tested up to: 4.0
+Tested up to: 4.1
 Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -83,5 +83,22 @@ When importing a local located website the index file can be referenced directly
 
 Settings defined in the XML file will override settings contained in the plugin settings page.
 
+== Roadmap ==
+The roadmap will be based on user demand and feedback.  Please provide feedback on what development would be important to you.  Some possibilities:
+* Option to import as a post
+* Overwriting of media files on subsequent imports or during filename conflicts.
+* Option to create new pages vs overwrite existing pages of the same name.
+* Option to set the category of the import based on the category the top level page has
+* Support for tags.
+* Support for categories and tags for media files.
+* Import from confluence index files.
+* Import from Subversion.
+* Ability to change content in HTML (eg, replacing tags, or sections of text).
+* Read in page information (such as tags or content) from custom-defined meta tags.
+If you find this plugin useful, or find that it could be useful with certain additions, please let me know.
+
 == Known Issues ==
-* Madcap Flare imports only support one chunk file, and the TOC must be named Toc.js and only the first chunk file will be loaded (using name [TOC_CHUNK_NAME]0.js.
+* Madcap Flare imports only support one chunk file, and the TOC must be named Toc.js and only the first chunk file will be loaded (using name [TOC_CHUNK_NAME]0.js).
+* During large Flare imports, the output text may stop printing even though the import completes.
+* Links that link to within the current page (thispage.html#section) are not relinked.
+* Relative links that do not specify http:// or https:// will not be relinked.

--- a/admin/includes/ArraySetting.php
+++ b/admin/includes/ArraySetting.php
@@ -64,22 +64,6 @@ class ArraySetting implements PluginSettingInterface {
 	}
 
 	/**
-	 * Escapes the value of the setting before providing, makes it safe to display in webpages.
-	 * @return mixed
-	 */
-	public function getEscapedHTMLValue() {
-		return esc_html( $this->getValue( $this->index ) );
-	}
-
-	/**
-	 * Returns the name of the setting
-	 * @return mixed
-	 */
-	public function getName() {
-		return $this->name;
-	}
-
-	/**
 	 * Returns the value an in the array.  If $index is null then it will use the current element.  Otherwise it returns the element at the position defined by $index.  If $index is larger than the size of the array, or there is no value there, then it returns null.
 	 *
 	 * @param int|null $index
@@ -101,6 +85,22 @@ class ArraySetting implements PluginSettingInterface {
 		} else {
 			return $this->value[$i];
 		}
+	}
+
+	/**
+	 * Escapes the value of the setting before providing, makes it safe to display in webpages.
+	 * @return mixed
+	 */
+	public function getEscapedHTMLValue() {
+		return esc_html( $this->getValue( $this->index ) );
+	}
+
+	/**
+	 * Returns the name of the setting
+	 * @return mixed
+	 */
+	public function getName() {
+		return $this->name;
 	}
 
 	/**

--- a/admin/includes/HtmlImportSettings.php
+++ b/admin/includes/HtmlImportSettings.php
@@ -8,8 +8,6 @@
 
 namespace html_import\admin;
 
-use html_import\indices\WebPageSettings;
-
 require_once( dirname( __FILE__ ) . '/PluginSettingsInterface.php' );
 require_once( dirname( __FILE__ ) . '/StringSetting.php' );
 require_once( dirname( __FILE__ ) . '/ArraySetting.php' );
@@ -23,6 +21,13 @@ class HtmlImportSettings implements PluginSettingsInterface {
 	const SETTINGS_NAME = 'htim_importer_options';
 
 	// TODO: radio/checkbox type options should have set enum types available to them
+	const INDEX_DEFAULT = 'flare';
+	const FILE_TYPE_DEFAULT = 'zip';
+	const IMPORT_SRC_DEFAULT = 'upload';
+	const PARENT_PAGE_DEFAULT = 0;
+	const TEMPLATE_DEFAULT = 0;
+	const FILE_LOCATION_DEFAULT = '';
+	const OVERWRITE_FILES_DEFAULT = 'true';
 	private $index_type = null;
 	private $file_type = null;
 	private $import_source = null;
@@ -31,14 +36,6 @@ class HtmlImportSettings implements PluginSettingsInterface {
 	private $template = null;
 	private $category = null;
 	private $doesOverwriteFiles = null;
-
-	const INDEX_DEFAULT = 'flare';
-	const FILE_TYPE_DEFAULT = 'zip';
-	const IMPORT_SRC_DEFAULT = 'upload';
-	const PARENT_PAGE_DEFAULT = 0;
-	const TEMPLATE_DEFAULT = 0;
-	const FILE_LOCATION_DEFAULT = '';
-	const OVERWRITE_FILES_DEFAULT = 'true';
 
 	/**
 	 * Instantiates all of the settings available for the plugin
@@ -52,20 +49,6 @@ class HtmlImportSettings implements PluginSettingsInterface {
 		$this->template           = new StringSetting( 'template' );
 		$this->category           = new ArraySetting( 'category' );
 		$this->doesOverwriteFiles = new StringSetting( 'overwrite-files' ); // TODO: should make a BoolSetting
-	}
-
-	/**
-	 * Populate all settings with default values.
-	 */
-	private function loadDefaults() {
-		$this->index_type->setSettingValue( self::INDEX_DEFAULT );
-		$this->file_type->setSettingValue( self::FILE_TYPE_DEFAULT );
-		$this->import_source->setSettingValue( self::IMPORT_SRC_DEFAULT );
-		$this->parent_page->setSettingValue( self::PARENT_PAGE_DEFAULT );
-		$this->template->setSettingValue( self::TEMPLATE_DEFAULT );
-		$this->file_location->setSettingValue( self::FILE_LOCATION_DEFAULT );
-		$this->category->setSettingValue( 0, 0 ); // TODO: 0 as default "none", could be better
-		$this->doesOverwriteFiles->setSettingValue( self::OVERWRITE_FILES_DEFAULT );
 	}
 
 	/**
@@ -115,6 +98,20 @@ class HtmlImportSettings implements PluginSettingsInterface {
 				break;
 			}
 		} while ( 1 == 1 );
+	}
+
+	/**
+	 * Populate all settings with default values.
+	 */
+	private function loadDefaults() {
+		$this->index_type->setSettingValue( self::INDEX_DEFAULT );
+		$this->file_type->setSettingValue( self::FILE_TYPE_DEFAULT );
+		$this->import_source->setSettingValue( self::IMPORT_SRC_DEFAULT );
+		$this->parent_page->setSettingValue( self::PARENT_PAGE_DEFAULT );
+		$this->template->setSettingValue( self::TEMPLATE_DEFAULT );
+		$this->file_location->setSettingValue( self::FILE_LOCATION_DEFAULT );
+		$this->category->setSettingValue( 0, 0 ); // TODO: 0 as default "none", could be better
+		$this->doesOverwriteFiles->setSettingValue( self::OVERWRITE_FILES_DEFAULT );
 	}
 
 	/**

--- a/admin/includes/StringSetting.php
+++ b/admin/includes/StringSetting.php
@@ -55,6 +55,14 @@ class StringSetting implements PluginSettingInterface {
 	}
 
 	/**
+	 * Returns the settings value.
+	 * @return mixed
+	 */
+	public function getValue() {
+		return $this->value;
+	}
+
+	/**
 	 * Escapes the value of the setting before providing, makes it safe to display in webpages.
 	 * @return mixed
 	 */
@@ -68,14 +76,6 @@ class StringSetting implements PluginSettingInterface {
 	 */
 	public function getName() {
 		return $this->name;
-	}
-
-	/**
-	 * Returns the settings value.
-	 * @return mixed
-	 */
-	public function getValue() {
-		return $this->value;
 	}
 
 	/**

--- a/admin/views/admin.php
+++ b/admin/views/admin.php
@@ -69,9 +69,10 @@ $settings->loadFromDB();
 
 		<h3>Select the type of import index</h3>
 		<label for="index-type-xml"><input type="radio" name="index-type" id="index-type-xml" value="xml" <?php checked( strcmp( 'xml', $settings->getIndexType()->getValue() ), 0, true ); ?>/>Confluence XML</label><br>
-		<a href="#" target="_none" id="showXML" onclick="javascript: jQuery('#showXML').hide('fast');  jQuery('#hideXML').show('fast'); jQuery('#SampleXML').show('fast');">Show XML Example</a>
-		<a href="#" target="_none" id="hideXML" style="display:none;" onclick="javascript: jQuery('#showXML').show('fast');  jQuery('#hideXML').hide('fast'); jQuery('#SampleXML').hide('fast');">Hide XML Example</a>
-			<div id="SampleXML" style="display:none;">
+		<a href="#" target="_self" id="showXML" onclick="javascript: jQuery('#showXML').hide('fast');  jQuery('#hideXML').show('fast'); jQuery('#SampleXML').show('fast');">Show XML Example</a>
+		<a href="#" target="_self" id="hideXML" style="display:none;" onclick="javascript: jQuery('#showXML').show('fast');  jQuery('#hideXML').hide('fast'); jQuery('#SampleXML').hide('fast');">Hide XML Example</a>
+
+		<div id="SampleXML" style="display:none;">
 				<pre>&lt;knowledgebase version="1.0"&gt;
   &lt;document title="First File" src="first.html" category="category1" order="1"&gt;
   &lt;/document&gt;
@@ -80,7 +81,7 @@ $settings->loadFromDB();
     &lt;/document&gt;
   &lt;/document&gt;
 &lt;/knowledgebase&gt;</pre>
-			</div>
+		</div>
 		<br>
 		<label for="index-type-flare"><input type="radio" name="index-type" id="index-type-flare" value="flare" <?php checked( strcmp( 'flare', $settings->getIndexType()->getValue() ), 0, true ); ?> />MadCap Flare</label><br>
 		</p>
@@ -167,12 +168,13 @@ $settings->loadFromDB();
 
 		<h3>Select the Categories for the imported files</h3>
 		<?php
-			if (!class_exists("PTCFP")) { // check for the Post Tags and Categories for Pages plugin
-				?>
-				<h4>* <a href="https://wordpress.org/plugins/post-tags-and-categories-for-pages/">Post Tags and Categories for Pages</a> is a required plugin in order to use categories.
-				</h4>
-			<?php
-			}
+		if ( !class_exists( "PTCFP" ) ) { // check for the Post Tags and Categories for Pages plugin
+			?>
+			<h4>*
+				<a href="https://wordpress.org/plugins/post-tags-and-categories-for-pages/">Post Tags and Categories for Pages</a> is a required plugin in order to use categories.
+			</h4>
+		<?php
+		}
 		?>
 		<div id="settings-categories">
 			<select id="select-categories" multiple name="category[]" size="8">
@@ -180,6 +182,7 @@ $settings->loadFromDB();
 
 				/**
 				 * Given a category ID return all of the categories, by hierarchy with indenting as OPTIONS for a SELECT.
+				 *
 				 * @param $category_id
 				 * @param $settings
 				 */

--- a/includes/DoubleLinkedList.php
+++ b/includes/DoubleLinkedList.php
@@ -128,20 +128,6 @@ class DoubleLinkedList {
 	}
 
 	/**
-	 * Returns a reference to the head node in the linked list to which this node belongs.
-	 * If this node is the head, it will return itself.
-	 * @return DoubleLinkedList
-	 */
-	public function head() {
-		$previous = $this;
-		while ( !is_null( $previous->previous ) ) {
-			$previous = $previous->previous;
-		}
-
-		return $previous;
-	}
-
-	/**
 	 * Returns a reference to the tail node in the linked list to which this node belongs.
 	 * If this node is the tail, it will return itself.
 	 * @return DoubleLinkedList
@@ -168,6 +154,20 @@ class DoubleLinkedList {
 		}
 
 		return $counter;
+	}
+
+	/**
+	 * Returns a reference to the head node in the linked list to which this node belongs.
+	 * If this node is the head, it will return itself.
+	 * @return DoubleLinkedList
+	 */
+	public function head() {
+		$previous = $this;
+		while ( !is_null( $previous->previous ) ) {
+			$previous = $previous->previous;
+		}
+
+		return $previous;
 	}
 
 	/**

--- a/public/HTMLImportPlugin.php
+++ b/public/HTMLImportPlugin.php
@@ -49,7 +49,14 @@ class HTMLImportPlugin {
 	 * @var     string
 	 */
 	const VERSION = '1.0.0';
-
+	/**
+	 * Instance of this class.
+	 *
+	 * @since    1.0.0
+	 *
+	 * @var      object
+	 */
+	protected static $instance = null;
 	/**
 	 *
 	 * Unique identifier for your plugin.
@@ -64,15 +71,6 @@ class HTMLImportPlugin {
 	 * @var      string
 	 */
 	protected $plugin_slug = 'htim-html-import';
-
-	/**
-	 * Instance of this class.
-	 *
-	 * @since    1.0.0
-	 *
-	 * @var      object
-	 */
-	protected static $instance = null;
 
 	/**
 	 * Initialize the plugin by setting localization and loading public scripts
@@ -92,17 +90,6 @@ class HTMLImportPlugin {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
-	}
-
-	/**
-	 * Return the plugin slug.
-	 *
-	 * @since    1.0.0
-	 *
-	 * @return    Plugin slug variable.
-	 */
-	public function get_plugin_slug() {
-		return $this->plugin_slug;
 	}
 
 	/**
@@ -160,6 +147,43 @@ class HTMLImportPlugin {
 	}
 
 	/**
+	 * Get all blog ids of blogs in the current network that are:
+	 * - not archived
+	 * - not spam
+	 * - not deleted
+	 *
+	 * @since    1.0.0
+	 *
+	 * @return   array|false    The blog ids, false if no matches.
+	 */
+	private static function get_blog_ids() {
+
+		global $wpdb;
+
+		// get an array of blog ids
+		$sql = "SELECT blog_id FROM $wpdb->blogs
+			WHERE archived = '0' AND spam = '0'
+			AND deleted = '0'";
+
+		return $wpdb->get_col( $sql );
+
+	}
+
+	/**
+	 * Fired for each blog when the plugin is activated.
+	 *
+	 * @since    1.0.0
+	 */
+	private static function single_activate() {
+
+		$settings = new \html_import\admin\HtmlImportSettings();
+		if ( !get_option( $settings::SETTINGS_NAME ) ) {
+			$settings->saveToDB();
+		}
+
+	}
+
+	/**
 	 * Fired when the plugin is deactivated.
 	 *
 	 * @since    1.0.0
@@ -198,6 +222,26 @@ class HTMLImportPlugin {
 	}
 
 	/**
+	 * Fired for each blog when the plugin is deactivated.
+	 *
+	 * @since    1.0.0
+	 */
+	private static function single_deactivate() {
+
+	}
+
+	/**
+	 * Return the plugin slug.
+	 *
+	 * @since    1.0.0
+	 *
+	 * @return    Plugin slug variable.
+	 */
+	public function get_plugin_slug() {
+		return $this->plugin_slug;
+	}
+
+	/**
 	 * Fired when a new site is activated with a WPMU environment.
 	 *
 	 * @since    1.0.0
@@ -213,52 +257,6 @@ class HTMLImportPlugin {
 		switch_to_blog( $blog_id );
 		self::single_activate();
 		restore_current_blog();
-
-	}
-
-	/**
-	 * Get all blog ids of blogs in the current network that are:
-	 * - not archived
-	 * - not spam
-	 * - not deleted
-	 *
-	 * @since    1.0.0
-	 *
-	 * @return   array|false    The blog ids, false if no matches.
-	 */
-	private static function get_blog_ids() {
-
-		global $wpdb;
-
-		// get an array of blog ids
-		$sql = "SELECT blog_id FROM $wpdb->blogs
-			WHERE archived = '0' AND spam = '0'
-			AND deleted = '0'";
-
-		return $wpdb->get_col( $sql );
-
-	}
-
-	/**
-	 * Fired for each blog when the plugin is activated.
-	 *
-	 * @since    1.0.0
-	 */
-	private static function single_activate() {
-
-		$settings = new \html_import\admin\HtmlImportSettings();
-		if ( !get_option( $settings::SETTINGS_NAME ) ) {
-			$settings->saveToDB();
-		}
-
-	}
-
-	/**
-	 * Fired for each blog when the plugin is deactivated.
-	 *
-	 * @since    1.0.0
-	 */
-	private static function single_deactivate() {
 
 	}
 
@@ -296,47 +294,158 @@ class HTMLImportPlugin {
 	}
 
 	/**
-	 * Imports a WebPage object into Wordpress, using the provided HtMLImportSettings, and assigning it to be a child of the post with the id defined in $parent_page_id.  $html_post_lookup is used to determine if the page had already been created by this session's import.
-	 * @param \html_import\indices\WebPage          $webPage
-	 * @param \html_import\admin\HtmlImportSettings $globalSettings
-	 * @param                                       $parent_page_id
-	 * @param                                       $html_post_lookup
+	 * Base function to import a website into Wordpress.  Takes $settings that have been set in the plugin's settings page, and uses $_FILES to access uploaded files (if required).  In the end all pages and media should be imported into Wordpress with internal links updated.
 	 *
-	 * @return \html_import\WPMetaConfigs
+	 * @param \html_import\admin\HtmlImportSettings $settings
 	 */
-	private function importAnHTML( \html_import\indices\WebPage $webPage, html_import\admin\HtmlImportSettings $globalSettings, $parent_page_id, $html_post_lookup ) {
+	public function importHTMLFiles( html_import\admin\HtmlImportSettings $settings ) {
+		echo '<h2>Output from Import</h2><br>Please be patient</br>';
+		echo '<ul>';
 
-		$title = $webPage->getTitle();
-
-		$pageMeta = new \html_import\WPMetaConfigs();
-		$post_id  = null;
-
-		// determine if the page has already been imported, search by post title
-		$post = get_page_by_title( htmlspecialchars( $title ) );// TODO: bad form, its saved with htmlspecialchars so need to search using that.  Need to find a way to not require this knowledge
-		if ( isset( $html_post_lookup ) ) {
-			// check to see if there's been an import of this page already, if so get its ID from the lookup
-			if ( array_key_exists( $webPage->getFullPath(), $html_post_lookup ) ) {
-				$post_id = $html_post_lookup[$webPage->getFullPath()];
-			} else {
-				// the post wasn't imported during this import, but a post already exists with its title.  Use it.
-				if ( !is_null( $post ) ) {
-					$post_id = $post->ID;
-					echo '<li>Page with title ' . $title . ' and ID ' . $post_id . ' already exists, now tagged to be overwritten.</li>';
+		// TODO: prefer to pass this value in rather than use global
+		$zip_to_upload = $_FILES['file-upload'];
+		if ( strcmp( 'upload', $settings->getImportSource()->getValue() ) == 0 ) {
+			$mime_type = $zip_to_upload['type'];
+			echo 'uploading file of mime-type ' . $mime_type . ' <br>';
+			if ( $this->isFileMimeTypeCompressed( $mime_type ) ) {
+				// echo 'mime-type: '.$mime_type;
+				$filePath = $this->decompressAndUploadFiletoSite( $zip_to_upload );
+				if ( !is_null( $filePath ) ) {
+					$this->routeImportToCorrectImporter( $filePath, $settings );
+					// clean up the files that were unzipped
+					html_import\FileHelper::delTree( $filePath );
 				}
 			}
-		}
-		$pageMeta->buildConfig( $globalSettings, $webPage, $post_id, $parent_page_id );
-
-		if ( !is_null( $title ) ) {
-			$pageMeta->setPostTitle( $title );
+		} else {
+			$this->routeImportToCorrectImporter( $settings->getFileLocation()->getValue(), $settings );
 		}
 
-		return $pageMeta;
+		echo '</ul>';
 	}
 
+	/**
+	 * Tests the provided Mime type to determine if it s a compressed file, such as RAR or ZIP.  Returns true if it is.
+	 *
+	 * @param $mime_type
+	 *
+	 * @return bool
+	 */
+	private function isFileMimeTypeCompressed( $mime_type ) {
+		// TODO: better would be to actually check the zip rather than just assume the mime-type is correct
+		return ( ( strcmp( 'application/x-rar-compressed', $mime_type ) == 0 ) || ( strcmp( 'application/octet-stream', $mime_type ) == 0 ) || ( strcmp( 'application/zip', $mime_type ) == 0 ) || ( strcmp( 'application/x-zip-compressed', $mime_type ) == 0 ) );
+	}
+
+	/**
+	 * Takes the path to a zip file, decompresses it and drops it into the Uploads directory of the Wordpress installation.  The sub path will be /import-# where # is a sequential number, incremented if there is another /import-# directory in the uploads directory.  A string is returned containing the path to the contents of the zip.
+	 *
+	 * @param $zip_to_upload
+	 *
+	 * @return null|string
+	 */
+	private function decompressAndUploadFiletoSite( $zip_to_upload ) {
+		$zip           = new ZipArchive;
+		$zipOpenResult = $zip->open( $zip_to_upload['tmp_name'] );
+		if ( $zipOpenResult === TRUE ) {
+			$upload_dir    = wp_upload_dir();
+			$path          = $upload_dir['path'] . '/import';
+			$path_modifier = 1;
+			while ( file_exists( $path . '-' . $path_modifier ) ) {
+				$path_modifier ++;
+			}
+			$resultingPath = $path . '-' . $path_modifier;
+
+			$extractSuccess = $zip->extractTo( $path . '-' . $path_modifier );
+			if ( $extractSuccess !== FALSE ) {
+				$closeSuccess = $zip->close();
+				if ( $closeSuccess === FALSE ) {
+					echo '*** Could not close the zip archive.';
+				}
+
+				return $resultingPath;
+			} else {
+				echo '*** Could not extract the zip archive.';
+
+				return null;
+			}
+		} else {
+			echo '*** Could not close the zip file. Error: ' . $zipOpenResult;
+
+			return null;
+		}
+	}
+
+	/**
+	 * Determines if the import is an XML or flare index and ensures it is imported accordingly.
+	 *
+	 * @param                                       $filePath
+	 * @param \html_import\admin\HtmlImportSettings $settings
+	 */
+	private function routeImportToCorrectImporter( $filePath, html_import\admin\HtmlImportSettings $settings ) {
+		$importType = $settings->getIndexType()->getValue();
+
+		if ( strcmp( 'flare', $importType ) == 0 ) {
+			$this->import_html_from_flare( $filePath, $settings );
+		} else {
+			if ( strcmp( 'xml', $importType ) == 0 ) {
+				$this->import_html_from_xml_index( $filePath, $settings );
+			} else {
+				echo '*** Unsupported import type: ' . $importType . '<br>';
+			}
+		}
+	}
+
+	/**
+	 * Begins the process of importing a website that is defined through a flare index file.  $filePath points to the index file, and $settings contains all of the settings to be applied to imported pages.  At the end of the import all of the pages listed in the index file will be imported into wordpress and have their parent, and categories defined by the $settings.
+	 *
+	 * @param                                       $filePath
+	 * @param \html_import\admin\HtmlImportSettings $settings
+	 */
+	private function import_html_from_flare( $filePath, html_import\admin\HtmlImportSettings $settings ) {
+		$localFileRetriever = new \droppedbars\files\LocalAndURLFileRetriever( $filePath );
+		$flareIndex         = new \html_import\indices\FlareWebsiteIndex( $localFileRetriever );
+		$flareIndex->buildHierarchyFromWebsiteIndex();
+		// TODO: note, the retriever is built with the directory, and the index found afterwards
+
+		$media_lookup     = Array();
+		$html_post_lookup = Array();
+		// perform the import twice, once to create stub files, and once to put in the contents and update links between files.
+		$html_post_lookup = $this->importFromWebsiteIndex( $flareIndex, true, $html_post_lookup, $media_lookup, $settings );
+		$this->importFromWebsiteIndex( $flareIndex, false, $html_post_lookup, $media_lookup, $settings );
+	}
+
+	/**
+	 * Iterates through the contents of a website index and imports the WebPages contained.  This function should be run twice, once to create a stub ($stubs_only = true) and once to create the full page. The reason for this is that local links cannot be updated unless a page has already been imported and has a Wordpress page_id.  All imported media files are returned in $media_lookup, and $html_post_lookup maintains a list of all pages that have been imported and their page_ids.
+	 *
+	 * @param \html_import\indices\WebsiteIndex     $siteIndex
+	 * @param bool                                  $stubs_only
+	 * @param null                                  $html_post_lookup
+	 * @param null                                  $media_lookup
+	 * @param \html_import\admin\HtmlImportSettings $settings
+	 *
+	 * @return array|null
+	 */
+	private function importFromWebsiteIndex( \html_import\indices\WebsiteIndex $siteIndex, $stubs_only = true, &$html_post_lookup = null, &$media_lookup = null, html_import\admin\HtmlImportSettings $settings ) {
+
+		set_time_limit( 520 ); // timeout of 520 seconds
+		if ( !isset( $html_post_lookup ) ) {
+			$html_post_lookup = Array();
+		}
+
+		// go through all the files in the hierarchy and import them.  Start at the base and keep going until all files are read in.
+		$siteIndex->setToFirstFile();
+		$fileNode = $siteIndex->getNextHTMLFile();
+
+		while ( !is_null( $fileNode ) ) {
+			$this->importAndRecordWebPage( $fileNode, $stubs_only, $html_post_lookup, $media_lookup, $settings );
+			$fileNode = $siteIndex->getNextHTMLFile();
+		}
+
+		return $html_post_lookup;
+	}
 
 	/**
 	 * Ensures the provided WebPage is imported into WordPress.  $stubs_only will force the import to create a stub (only creates the page with a title, no content) or do a full import.  A record of the page being imported is stored in $html_post_lookup which is returned updated.  $media_lookup maintains a list of all local media files that have been imported, and it is updated during the course of this import and returned.  The HtmlImportSettings defines various settings to apply to the imported page.
+	 *
 	 * @param \html_import\indices\WebPage          $webPage
 	 * @param bool                                  $stubs_only
 	 * @param                                       $html_post_lookup
@@ -400,37 +509,51 @@ class HTMLImportPlugin {
 		return $postMeta;
 	}
 
+	// TODO: candidate to be made into a factory
+
 	/**
-	 * Iterates through the contents of a website index and imports the WebPages contained.  This function should be run twice, once to create a stub ($stubs_only = true) and once to create the full page. The reason for this is that local links cannot be updated unless a page has already been imported and has a Wordpress page_id.  All imported media files are returned in $media_lookup, and $html_post_lookup maintains a list of all pages that have been imported and their page_ids.
-	 * @param \html_import\indices\WebsiteIndex     $siteIndex
-	 * @param bool                                  $stubs_only
-	 * @param null                                  $html_post_lookup
-	 * @param null                                  $media_lookup
-	 * @param \html_import\admin\HtmlImportSettings $settings
+	 * Imports a WebPage object into Wordpress, using the provided HtMLImportSettings, and assigning it to be a child of the post with the id defined in $parent_page_id.  $html_post_lookup is used to determine if the page had already been created by this session's import.
 	 *
-	 * @return array|null
+	 * @param \html_import\indices\WebPage          $webPage
+	 * @param \html_import\admin\HtmlImportSettings $globalSettings
+	 * @param                                       $parent_page_id
+	 * @param                                       $html_post_lookup
+	 *
+	 * @return \html_import\WPMetaConfigs
 	 */
-	private function importFromWebsiteIndex( \html_import\indices\WebsiteIndex $siteIndex, $stubs_only = true, &$html_post_lookup = null, &$media_lookup = null, html_import\admin\HtmlImportSettings $settings ) {
+	private function importAnHTML( \html_import\indices\WebPage $webPage, html_import\admin\HtmlImportSettings $globalSettings, $parent_page_id, $html_post_lookup ) {
 
-		set_time_limit( 520 ); // timeout of 520 seconds
-		if ( !isset( $html_post_lookup ) ) {
-			$html_post_lookup = Array();
+		$title = $webPage->getTitle();
+
+		$pageMeta = new \html_import\WPMetaConfigs();
+		$post_id  = null;
+
+		// determine if the page has already been imported, search by post title
+		$post = get_page_by_title( htmlspecialchars( $title ) );// TODO: bad form, its saved with htmlspecialchars so need to search using that.  Need to find a way to not require this knowledge
+		if ( isset( $html_post_lookup ) ) {
+			// check to see if there's been an import of this page already, if so get its ID from the lookup
+			if ( array_key_exists( $webPage->getFullPath(), $html_post_lookup ) ) {
+				$post_id = $html_post_lookup[$webPage->getFullPath()];
+			} else {
+				// the post wasn't imported during this import, but a post already exists with its title.  Use it.
+				if ( !is_null( $post ) ) {
+					$post_id = $post->ID;
+					echo '<li>Page with title ' . $title . ' and ID ' . $post_id . ' already exists, now tagged to be overwritten.</li>';
+				}
+			}
+		}
+		$pageMeta->buildConfig( $globalSettings, $webPage, $post_id, $parent_page_id );
+
+		if ( !is_null( $title ) ) {
+			$pageMeta->setPostTitle( $title );
 		}
 
-		// go through all the files in the hierarchy and import them.  Start at the base and keep going until all files are read in.
-		$siteIndex->setToFirstFile();
-		$fileNode = $siteIndex->getNextHTMLFile();
-
-		while ( !is_null( $fileNode ) ) {
-			$this->importAndRecordWebPage( $fileNode, $stubs_only, $html_post_lookup, $media_lookup, $settings );
-			$fileNode = $siteIndex->getNextHTMLFile();
-		}
-
-		return $html_post_lookup;
+		return $pageMeta;
 	}
 
 	/**
 	 * Begins the process of importing a website that is defined through an XML index file.  $filePath points to the index file, and $settings contains all of the settings to be applied to imported pages.  At the end of the import all of the pages listed in the index file will be imported into Wordpress and have their parent, and categories defined by the $settings.
+	 *
 	 * @param                                       $filePath
 	 * @param \html_import\admin\HtmlImportSettings $settings
 	 */
@@ -455,119 +578,5 @@ class HTMLImportPlugin {
 		// perform the import twice, once to create stub files, and once to put in the contents and update links between files.
 		$html_post_lookup = $this->importFromWebsiteIndex( $xmlIndex, true, $html_post_lookup, $media_lookup, $settings );
 		$this->importFromWebsiteIndex( $xmlIndex, false, $html_post_lookup, $media_lookup, $settings );
-	}
-
-	/**
-	 * Tests the provided Mime type to determine if it s a compressed file, such as RAR or ZIP.  Returns true if it is.
-	 * @param $mime_type
-	 *
-	 * @return bool
-	 */
-	private function isFileMimeTypeCompressed( $mime_type ) {
-		// TODO: better would be to actually check the zip rather than just assume the mime-type is correct
-		return ( ( strcmp( 'application/x-rar-compressed', $mime_type ) == 0 ) || ( strcmp( 'application/octet-stream', $mime_type ) == 0 ) || ( strcmp( 'application/zip', $mime_type ) == 0 ) || ( strcmp( 'application/x-zip-compressed', $mime_type ) == 0 ) );
-	}
-
-	/**
-	 * Takes the path to a zip file, decompresses it and drops it into the Uploads directory of the Wordpress installation.  The sub path will be /import-# where # is a sequential number, incremented if there is another /import-# directory in the uploads directory.  A string is returned containing the path to the contents of the zip.
-	 * @param $zip_to_upload
-	 *
-	 * @return null|string
-	 */
-	private function decompressAndUploadFiletoSite( $zip_to_upload ) {
-		$zip = new ZipArchive;
-		$zipOpenResult = $zip->open( $zip_to_upload['tmp_name'] );
-		if ( $zipOpenResult === TRUE ) {
-			$upload_dir    = wp_upload_dir();
-			$path          = $upload_dir['path'] . '/import';
-			$path_modifier = 1;
-			while ( file_exists( $path . '-' . $path_modifier ) ) {
-				$path_modifier ++;
-			}
-			$resultingPath = $path . '-' . $path_modifier;
-
-			$extractSuccess = $zip->extractTo( $path . '-' . $path_modifier );
-			if ($extractSuccess !== FALSE) {
-				$closeSuccess = $zip->close();
-				if ( $closeSuccess === FALSE ) {
-					echo '*** Could not close the zip archive.';
-				}
-
-				return $resultingPath;
-			} else {
-				echo '*** Could not extract the zip archive.';
-				return null;
-			}
-	} else {
-			echo '*** Could not close the zip file. Error: '.$zipOpenResult;
-			return null;
-		}
-	}
-
-	/**
-	 * Begins the process of importing a website that is defined through a flare index file.  $filePath points to the index file, and $settings contains all of the settings to be applied to imported pages.  At the end of the import all of the pages listed in the index file will be imported into wordpress and have their parent, and categories defined by the $settings.
-	 * @param                                       $filePath
-	 * @param \html_import\admin\HtmlImportSettings $settings
-	 */
-	private function import_html_from_flare( $filePath, html_import\admin\HtmlImportSettings $settings ) {
-		$localFileRetriever = new \droppedbars\files\LocalAndURLFileRetriever( $filePath );
-		$flareIndex         = new \html_import\indices\FlareWebsiteIndex( $localFileRetriever );
-		$flareIndex->buildHierarchyFromWebsiteIndex();
-		// TODO: note, the retriever is built with the directory, and the index found afterwards
-
-		$media_lookup     = Array();
-		$html_post_lookup = Array();
-		// perform the import twice, once to create stub files, and once to put in the contents and update links between files.
-		$html_post_lookup = $this->importFromWebsiteIndex( $flareIndex, true, $html_post_lookup, $media_lookup, $settings );
-		$this->importFromWebsiteIndex( $flareIndex, false, $html_post_lookup, $media_lookup, $settings );
-	}
-
-	// TODO: candidate to be made into a factory
-	/**
-	 * Determines if the import is an XML or flare index and ensures it is imported accordingly.
-	 * @param                                       $filePath
-	 * @param \html_import\admin\HtmlImportSettings $settings
-	 */
-	private function routeImportToCorrectImporter( $filePath, html_import\admin\HtmlImportSettings $settings ) {
-		$importType = $settings->getIndexType()->getValue();
-
-		if ( strcmp( 'flare', $importType ) == 0 ) {
-			$this->import_html_from_flare( $filePath, $settings );
-		} else {
-			if ( strcmp( 'xml', $importType ) == 0 ) {
-				$this->import_html_from_xml_index( $filePath, $settings );
-			} else {
-				echo '*** Unsupported import type: '. $importType .'<br>';
-			}
-		}
-	}
-
-	/**
-	 * Base function to import a website into Wordpress.  Takes $settings that have been set in the plugin's settings page, and uses $_FILES to access uploaded files (if required).  In the end all pages and media should be imported into Wordpress with internal links updated.
-	 * @param \html_import\admin\HtmlImportSettings $settings
-	 */
-	public function importHTMLFiles( html_import\admin\HtmlImportSettings $settings ) {
-		echo '<h2>Output from Import</h2><br>Please be patient</br>';
-		echo '<ul>';
-
-		// TODO: prefer to pass this value in rather than use global
-		$zip_to_upload = $_FILES['file-upload'];
-		if ( strcmp( 'upload', $settings->getImportSource()->getValue() ) == 0 ) {
-			$mime_type = $zip_to_upload['type'];
-			echo 'uploading file of mime-type ' . $mime_type . ' <br>';
-			if ( $this->isFileMimeTypeCompressed( $mime_type ) ) {
-				// echo 'mime-type: '.$mime_type;
-				$filePath = $this->decompressAndUploadFiletoSite( $zip_to_upload );
-				if ( !is_null( $filePath ) ) {
-					$this->routeImportToCorrectImporter( $filePath, $settings );
-					// clean up the files that were unzipped
-					html_import\FileHelper::delTree( $filePath );
-				}
-			}
-		} else {
-			$this->routeImportToCorrectImporter( $settings->getFileLocation()->getValue(), $settings );
-		}
-
-		echo '</ul>';
 	}
 }

--- a/public/includes/FolderImporter.php
+++ b/public/includes/FolderImporter.php
@@ -22,19 +22,21 @@ class FolderImporter extends Importer {
 
 	/**
 	 * Performs the import of the current webPage object as a folder.
+	 *
 	 * @param WebPage       $webPage
 	 * @param WPMetaConfigs $meta
-	 * @param Array|null          $html_post_lookup
-	 * @param Array|null          $media_lookup
+	 * @param Array|null    $html_post_lookup
+	 * @param Array|null    $media_lookup
+	 *
 	 * @return null
 	 */
 	protected function doImport( WebPage $webPage, WPMetaConfigs $meta, &$html_post_lookup = null, &$media_lookup = null ) {
-		$updateResult                                  = $meta->updateWPPost();
+		$updateResult = $meta->updateWPPost();
 
 		if ( is_wp_error( $updateResult ) ) {
 			echo '<li>***Unable to create folder ' . $meta->getPostTitle() . ' from ' . $meta->getSourcePath() . '</li>';
 		} else {
-			$webPage->setWPID($updateResult);
+			$webPage->setWPID( $updateResult );
 			echo '<li>Folder created from ' . $meta->getPostTitle() . ' into post #' . $updateResult . ' with title ' . $meta->getPostTitle() . '</li>';
 		}
 

--- a/public/includes/HTMLFullImporter.php
+++ b/public/includes/HTMLFullImporter.php
@@ -28,6 +28,7 @@ class HTMLFullImporter extends Importer {
 	/**
 	 * Initiates all of the import stages that can be executed.
 	 * $stages is responsible to define which stages actually will be actioned upon.
+	 *
 	 * @param admin\HtmlImportSettings $settings
 	 * @param HTMLImportStages         $stages
 	 */
@@ -42,6 +43,7 @@ class HTMLFullImporter extends Importer {
 
 	/**
 	 * Processes through each stage and if permitted, executes them.
+	 *
 	 * @param WebPage       $webPage
 	 * @param WPMetaConfigs $meta
 	 * @param null          $html_post_lookup

--- a/public/includes/HTMLImportStages.php
+++ b/public/includes/HTMLImportStages.php
@@ -21,6 +21,12 @@ class HTMLImportStages {
 	private $addGDNHeaderAndFooter = false;
 
 	/**
+	 *
+	 */
+	function __construct() {
+	}
+
+	/**
 	 * @param boolean $setTemplate
 	 */
 	public function setConfigureTemplate( $setTemplate ) {
@@ -88,12 +94,6 @@ class HTMLImportStages {
 	 */
 	public function doesUpdateLinks() {
 		return $this->updateLinks;
-	}
-
-	/**
-	 * 
-	 */
-	function __construct() {
 	}
 
 } 

--- a/public/includes/HTMLStubImporter.php
+++ b/public/includes/HTMLStubImporter.php
@@ -22,6 +22,7 @@ class HTMLStubImporter extends Importer {
 
 	/**
 	 * Executes the stub import by updating the Wordpress post and then adds its references to $html_post_lookup.
+	 *
 	 * @param WebPage       $webPage
 	 * @param WPMetaConfigs $meta
 	 * @param null          $html_post_lookup
@@ -36,7 +37,7 @@ class HTMLStubImporter extends Importer {
 		if ( is_wp_error( $updateResult ) ) {
 			echo '<li>***Unable to create content ' . $meta->getPostTitle() . ' from ' . $webPage->getFullPath() . '</li>';
 		} else {
-			$webPage->setWPID($updateResult);
+			$webPage->setWPID( $updateResult );
 			echo '<li>Stub post created from ' . $webPage->getFullPath() . ' into post #' . $updateResult . ' with title ' . $meta->getPostTitle() . '</li>';
 		}
 

--- a/public/includes/ImportHTMLStage.php
+++ b/public/includes/ImportHTMLStage.php
@@ -28,6 +28,7 @@ class ImportHTMLStage extends ImportStage {
 
 	/**
 	 * Executes the actual stage of importing the HTML contents.  <BODY> tags are converted to <DIV> tags.
+	 *
 	 * @param WebPage          $webPage
 	 * @param HTMLImportStages $stagesSettings
 	 * @param WPMetaConfigs    $meta
@@ -41,6 +42,7 @@ class ImportHTMLStage extends ImportStage {
 
 	/**
 	 * Replaces all body tags with div dags.
+	 *
 	 * @param $body
 	 *
 	 * @return mixed

--- a/public/includes/ImportStage.php
+++ b/public/includes/ImportStage.php
@@ -18,21 +18,9 @@ require_once( dirname( __FILE__ ) . '/indices/WebPage.php' );
  * @package html_import
  */
 abstract class ImportStage {
-	abstract protected function isValid( HTMLImportStages $stagesSettings );
-
-	/**
-	 * Function responsible for actually performing the action of the import class.
-	 * @param WebPage          $webPage
-	 * @param HTMLImportStages $stagesSettings
-	 * @param WPMetaConfigs    $meta
-	 * @param null             $other
-	 *
-	 * @return mixed
-	 */
-	abstract protected function performStage( WebPage $webPage, HTMLImportStages $stagesSettings, WPMetaConfigs &$meta, &$other = null );
-
 	/**
 	 * Public function that is called to get the import stage to be activated.
+	 *
 	 * @param WebPage          $webPage
 	 * @param HTMLImportStages $stagesSettings
 	 * @param WPMetaConfigs    $meta
@@ -43,4 +31,18 @@ abstract class ImportStage {
 			$this->performStage( $webPage, $stagesSettings, $meta, $other );
 		}
 	}
+
+	abstract protected function isValid( HTMLImportStages $stagesSettings );
+
+	/**
+	 * Function responsible for actually performing the action of the import class.
+	 *
+	 * @param WebPage          $webPage
+	 * @param HTMLImportStages $stagesSettings
+	 * @param WPMetaConfigs    $meta
+	 * @param null             $other
+	 *
+	 * @return mixed
+	 */
+	abstract protected function performStage( WebPage $webPage, HTMLImportStages $stagesSettings, WPMetaConfigs &$meta, &$other = null );
 } 

--- a/public/includes/Importer.php
+++ b/public/includes/Importer.php
@@ -25,6 +25,7 @@ abstract class Importer {
 
 	/**
 	 * Initialize the object with settings for the import and the stages to be imported.
+	 *
 	 * @param admin\HtmlImportSettings $settings
 	 * @param HTMLImportStages         $stages
 	 */
@@ -35,10 +36,11 @@ abstract class Importer {
 
 	/**
 	 * Used to initiate the import of the webpage given configuration details.
+	 *
 	 * @param WebPage       $webPage
 	 * @param WPMetaConfigs $meta
-	 * @param Array|null          $html_post_lookup array of pages that have been imported
-	 * @param Array|null          $media_lookup array of media files that have been imported
+	 * @param Array|null    $html_post_lookup array of pages that have been imported
+	 * @param Array|null    $media_lookup     array of media files that have been imported
 	 */
 	public function import( WebPage $webPage, WPMetaConfigs $meta, &$html_post_lookup = null, &$media_lookup = null ) {
 		$this->doImport( $webPage, $meta, $html_post_lookup, $media_lookup );
@@ -47,17 +49,30 @@ abstract class Importer {
 
 	/**
 	 * Performs the actual import of the webpage.
+	 *
 	 * @param WebPage       $webPage
 	 * @param WPMetaConfigs $meta
-	 * @param Array|null          $html_post_lookup
-	 * @param Array|null          $media_lookup
+	 * @param Array|null    $html_post_lookup
+	 * @param Array|null    $media_lookup
 	 *
 	 * @return mixed
 	 */
 	abstract protected function doImport( WebPage $webPage, WPMetaConfigs $meta, &$html_post_lookup = null, &$media_lookup = null );
 
 	/**
+	 * Saves the post in wordpress.
+	 *
+	 * @param WPMetaConfigs $meta
+	 *
+	 * @return int|\WP_Error
+	 */
+	protected function save( WPMetaConfigs $meta ) {
+		return $meta->updateWPPost();
+	}
+
+	/**
 	 * Responsible for executing each individual stage as they are passed in.
+	 *
 	 * @param WebPage       $webPage
 	 * @param ImportStage   $stage
 	 * @param WPMetaConfigs $meta
@@ -65,15 +80,5 @@ abstract class Importer {
 	 */
 	protected function stageParse( WebPage $webPage, ImportStage $stage, WPMetaConfigs $meta, &$other ) {
 		$stage->process( $webPage, $this->stages, $meta, $other );
-	}
-
-	/**
-	 * Saves the post in wordpress.
-	 * @param WPMetaConfigs $meta
-	 *
-	 * @return int|\WP_Error
-	 */
-	protected function save( WPMetaConfigs $meta ) {
-		return $meta->updateWPPost();
 	}
 } 

--- a/public/includes/MediaImportStage.php
+++ b/public/includes/MediaImportStage.php
@@ -27,10 +27,12 @@ class MediaImportStage extends ImportStage {
 
 	/**
 	 * Performs the stage action of uploading media files and updating the WebPage accordingly.
+	 *
 	 * @param WebPage          $webPage
 	 * @param HTMLImportStages $stagesSettings
 	 * @param WPMetaConfigs    $meta
 	 * @param null             $media_lookup
+	 *
 	 * @return null
 	 */
 	protected function performStage( WebPage $webPage, HTMLImportStages $stagesSettings, WPMetaConfigs &$meta, &$media_lookup = null ) {

--- a/public/includes/SetTemplateStage.php
+++ b/public/includes/SetTemplateStage.php
@@ -27,10 +27,12 @@ class SetTemplateStage extends ImportStage {
 
 	/**
 	 * Performs the action of setting the appropriate template to the page.
+	 *
 	 * @param WebPage          $webPage
 	 * @param HTMLImportStages $stagesSettings
 	 * @param WPMetaConfigs    $meta
 	 * @param null             $other
+	 *
 	 * @return null
 	 */
 	protected function performStage( WebPage $webPage, HTMLImportStages $stagesSettings, WPMetaConfigs &$meta, &$other = null ) {

--- a/public/includes/UpdateLinksImportStage.php
+++ b/public/includes/UpdateLinksImportStage.php
@@ -27,10 +27,12 @@ class UpdateLinksImportStage extends ImportStage {
 
 	/**
 	 * Function that performs the action of updating the local links on the webpage.
+	 *
 	 * @param WebPage          $webPage
 	 * @param HTMLImportStages $stagesSettings
 	 * @param WPMetaConfigs    $meta
 	 * @param null             $html_post_lookup
+	 *
 	 * @return null
 	 */
 	protected function performStage( WebPage $webPage, HTMLImportStages $stagesSettings, WPMetaConfigs &$meta, &$html_post_lookup = null ) {
@@ -41,7 +43,7 @@ class UpdateLinksImportStage extends ImportStage {
 
 			$link_table = Array();
 			// get a list of all the links in the page and iterate through them
-			$all_links  = $bodyXML->xpath( '//a[@href]' );
+			$all_links = $bodyXML->xpath( '//a[@href]' );
 			// TODO: encapsulate this in a function use XMLHelper::getAllHRefsFromHTML as a start
 			if ( $all_links ) {
 				foreach ( $all_links as $link ) {

--- a/public/includes/WPMetaConfigs.php
+++ b/public/includes/WPMetaConfigs.php
@@ -36,6 +36,13 @@ class WPMetaConfigs {
 	private $source_path = '';
 
 	/**
+	 * @return string
+	 */
+	public function getSourcePath() {
+		return $this->source_path;
+	}
+
+	/**
 	 * @param string $source_path
 	 */
 	public function setSourcePath( $source_path ) {
@@ -43,12 +50,11 @@ class WPMetaConfigs {
 	}
 
 	/**
-	 * @return string
+	 * @return mixed
 	 */
-	public function getSourcePath() {
-		return $this->source_path;
+	public function getPageTemplate() {
+		return $this->page_template;
 	}
-
 
 	/**
 	 * @param mixed $page_template
@@ -60,8 +66,8 @@ class WPMetaConfigs {
 	/**
 	 * @return mixed
 	 */
-	public function getPageTemplate() {
-		return $this->page_template;
+	public function getPostContent() {
+		return $this->post_content;
 	}
 
 	/**
@@ -72,58 +78,18 @@ class WPMetaConfigs {
 	}
 
 	/**
-	 * @return mixed
+	 * Inserts the post into Wordpress and returns the resulting post ID.
+	 * @return int|\WP_Error
 	 */
-	public function getPostContent() {
-		return $this->post_content;
-	}
-
-	/**
-	 * Loads all of the meta data for a post given the post's ID.  Returns false of there is no post with that ID.
-	 * @param $post_id
-	 *
-	 * @return bool
-	 */
-	public function loadFromPostID( $post_id ) {
-		$post_object = get_post( $post_id, 'OBJECT' );
-		if ( is_null( $post_object ) ) {
-			return false;
-		} else {
-			return $this->loadFromPostObject( $post_object );
-		}
-	}
-
-	/**
-	 * Loads all of the meta data give an WP_Post object.  If there is no object, returns null.
-	 * @param \WP_Post $post
-	 *
-	 * @return bool
-	 */
-	public function loadFromPostObject( \WP_Post $post ) {
-		if ( is_null( $post ) ) {
-			return false;
+	public function updateWPPost() {
+		// TODO: handle WP_Error object if set to true.
+		$postArray = $this->getPostArray();
+		$result    = wp_insert_post( $postArray, true );
+		if ( !is_wp_error( $result ) ) {
+			$this->setPostId( $result );
 		}
 
-		$this->post_id     = $post->ID;
-		$this->post_author = $post->post_author;
-		$this->post_name   = $post->post_name;
-		$this->post_type   = $post->post_type;
-		$this->post_title  = $post->post_title;
-		$this->post_date   = $post->post_date;
-		// $post->post_date_gmt
-		$this->post_content   = $post->content;
-		$this->post_excerpt   = $post->post_excerpt;
-		$this->comment_status = $post->comment_status;
-		$this->ping_status    = $post->ping_status;
-		$this->post_status    = $post->post_status;
-		// $post->post_password
-		$this->post_parent = $post->post_parent;
-		// $post->post_modified
-		// $post->post_modified_gmt
-		// $post->comment_count
-		$this->menu_order = $post->menu_order;
-
-		return true;
+		return $result;
 	}
 
 	/**
@@ -161,18 +127,10 @@ class WPMetaConfigs {
 	}
 
 	/**
-	 * Inserts the post into Wordpress and returns the resulting post ID.
-	 * @return int|\WP_Error
+	 * @return mixed
 	 */
-	public function updateWPPost() {
-		// TODO: handle WP_Error object if set to true.
-		$postArray = $this->getPostArray();
-		$result    = wp_insert_post( $postArray, true );
-		if ( !is_wp_error( $result ) ) {
-			$this->setPostId( $result );
-		}
-
-		return $result;
+	public function getCommentStatus() {
+		return $this->comment_status;
 	}
 
 	/**
@@ -185,8 +143,8 @@ class WPMetaConfigs {
 	/**
 	 * @return mixed
 	 */
-	public function getCommentStatus() {
-		return $this->comment_status;
+	public function getMenuOrder() {
+		return $this->menu_order;
 	}
 
 	/**
@@ -199,38 +157,21 @@ class WPMetaConfigs {
 	/**
 	 * @return mixed
 	 */
-	public function getMenuOrder() {
-		return $this->menu_order;
+	public function getPingStatus() {
+		return $this->ping_status;
 	}
 
 	/**
 	 * @param mixed $ping_status
 	 */
 	public function setPingStatus( $ping_status ) {
-		if (!is_string($ping_status)) {
-			throw new \InvalidArgumentException("Post status must be a string");
+		if ( !is_string( $ping_status ) ) {
+			throw new \InvalidArgumentException( "Post status must be a string" );
 		}
-		if (($ping_status != 'closed') &&($ping_status != 'open')) {
-			throw new \InvalidArgumentException("Post status must be one of: closed, open");
+		if ( ( $ping_status != 'closed' ) && ( $ping_status != 'open' ) ) {
+			throw new \InvalidArgumentException( "Post status must be one of: closed, open" );
 		}
 		$this->ping_status = $ping_status;
-	}
-
-	/**
-	 * @return mixed
-	 */
-	public function getPingStatus() {
-		return $this->ping_status;
-	}
-
-	/**
-	 * @param mixed $post_author
-	 */
-	public function setPostAuthor( $post_author ) {
-		if (!is_integer($post_author) && (!is_null($post_author))) {
-			throw new \InvalidArgumentException("Post author ID must be an integer or null.");
-		}
-		$this->post_author = $post_author;
 	}
 
 	/**
@@ -241,14 +182,13 @@ class WPMetaConfigs {
 	}
 
 	/**
-	 * @param Array $post_category
+	 * @param mixed $post_author
 	 */
-	public function setPostCategory( Array $post_category ) {
-		if (!is_array($post_category) && (!is_null($post_category))) {
-			throw new \InvalidArgumentException("Post category must be an array or null.");
+	public function setPostAuthor( $post_author ) {
+		if ( !is_integer( $post_author ) && ( !is_null( $post_author ) ) ) {
+			throw new \InvalidArgumentException( "Post author ID must be an integer or null." );
 		}
-
-		$this->post_category = $post_category;
+		$this->post_author = $post_author;
 	}
 
 	/**
@@ -259,14 +199,33 @@ class WPMetaConfigs {
 	}
 
 	/**
+	 * @param Array $post_category
+	 */
+	public function setPostCategory( Array $post_category ) {
+		if ( !is_array( $post_category ) && ( !is_null( $post_category ) ) ) {
+			throw new \InvalidArgumentException( "Post category must be an array or null." );
+		}
+
+		$this->post_category = $post_category;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getPostDate() {
+		return $this->post_date;
+	}
+
+	/**
 	 * Sets the date and time in the appropriate format for Wordpress.  If null is passed in, then the current datetime as calculated by time() will be used.
+	 *
 	 * @param integer $post_date
 	 */
 	public function setPostDate( $post_date ) {
-		if (!is_integer($post_date) && (!is_null($post_date))) {
-			throw new \InvalidArgumentException("Post date must be an integer or null.");
+		if ( !is_integer( $post_date ) && ( !is_null( $post_date ) ) ) {
+			throw new \InvalidArgumentException( "Post date must be an integer or null." );
 		}
-		if (is_null($post_date)) {
+		if ( is_null( $post_date ) ) {
 			$datetime = time();
 		} else {
 			$datetime = $post_date;
@@ -278,8 +237,8 @@ class WPMetaConfigs {
 	/**
 	 * @return mixed
 	 */
-	public function getPostDate() {
-		return $this->post_date;
+	public function getPostExcerpt() {
+		return $this->post_excerpt;
 	}
 
 	/**
@@ -292,33 +251,18 @@ class WPMetaConfigs {
 	/**
 	 * @return mixed
 	 */
-	public function getPostExcerpt() {
-		return $this->post_excerpt;
+	public function getPostId() {
+		return $this->post_id;
 	}
 
 	/**
 	 * @param mixed $post_id
 	 */
 	public function setPostId( $post_id ) {
-		if (!is_integer($post_id) && (!is_null($post_id))) {
-			throw new \InvalidArgumentException("Post ID must be an integer or null.");
+		if ( !is_integer( $post_id ) && ( !is_null( $post_id ) ) ) {
+			throw new \InvalidArgumentException( "Post ID must be an integer or null." );
 		}
 		$this->post_id = $post_id;
-	}
-
-	/**
-	 * @return mixed
-	 */
-	public function getPostId() {
-		return $this->post_id;
-	}
-
-	/**
-	 * Given a name for the post, sets it to the meta data but sanitized with dashes instead of spaces.
-	 * @param mixed $post_name
-	 */
-	public function setPostName( $post_name ) {
-		$this->post_name = sanitize_title_with_dashes( $post_name );
 	}
 
 	/**
@@ -329,13 +273,12 @@ class WPMetaConfigs {
 	}
 
 	/**
-	 * @param mixed $post_parent
+	 * Given a name for the post, sets it to the meta data but sanitized with dashes instead of spaces.
+	 *
+	 * @param mixed $post_name
 	 */
-	public function setPostParent( $post_parent ) {
-		if (!is_integer($post_parent) && (!is_null($post_parent))) {
-			throw new \InvalidArgumentException("Post parent ID must be an integer or null.");
-		}
-		$this->post_parent = $post_parent;
+	public function setPostName( $post_name ) {
+		$this->post_name = sanitize_title_with_dashes( $post_name );
 	}
 
 	/**
@@ -346,17 +289,13 @@ class WPMetaConfigs {
 	}
 
 	/**
-	 * @param mixed $post_status
+	 * @param mixed $post_parent
 	 */
-	public function setPostStatus( $post_status ) {
-		if (!is_string($post_status) && !is_null($post_status)) {
-			throw new \InvalidArgumentException("Post status must be a string or null.");
+	public function setPostParent( $post_parent ) {
+		if ( !is_integer( $post_parent ) && ( !is_null( $post_parent ) ) ) {
+			throw new \InvalidArgumentException( "Post parent ID must be an integer or null." );
 		}
-		if (($post_status != 'publish') &&($post_status != 'pending')&&($post_status != 'draft')&&($post_status != 'auto-draft')&&($post_status != 'future')&&($post_status != 'inherit')&&($post_status != 'trash')) {
-			throw new \InvalidArgumentException("Post status must be one of: publish, pending, draft, auto-draft, future, inherit, trash");
-		}
-
-		$this->post_status = $post_status;
+		$this->post_parent = $post_parent;
 	}
 
 	/**
@@ -367,31 +306,17 @@ class WPMetaConfigs {
 	}
 
 	/**
-	 * @param mixed $post_title
+	 * @param mixed $post_status
 	 */
-	public function setPostTitle( $post_title ) {
-		if (!is_string($post_title) && !is_null($post_title)) {
-			throw new \InvalidArgumentException("Post title must be a string or null.");
+	public function setPostStatus( $post_status ) {
+		if ( !is_string( $post_status ) && !is_null( $post_status ) ) {
+			throw new \InvalidArgumentException( "Post status must be a string or null." );
 		}
-		$this->post_title = htmlspecialchars( $post_title );
-	}
-
-	/**
-	 * @return mixed
-	 */
-	public function getPostTitle() {
-		return $this->post_title;
-	}
-
-	/**
-	 * @param mixed $post_type
-	 */
-	public function setPostType( $post_type ) {
-		if (!is_string($post_type) && !is_null($post_type)) {
-			throw new \InvalidArgumentException("Post type must be a string or null.");
+		if ( ( $post_status != 'publish' ) && ( $post_status != 'pending' ) && ( $post_status != 'draft' ) && ( $post_status != 'auto-draft' ) && ( $post_status != 'future' ) && ( $post_status != 'inherit' ) && ( $post_status != 'trash' ) ) {
+			throw new \InvalidArgumentException( "Post status must be one of: publish, pending, draft, auto-draft, future, inherit, trash" );
 		}
-		// typical values 'post' | 'page' | 'link' | 'nav_menu_item' | custom post type
-		$this->post_type = $post_type;
+
+		$this->post_status = $post_status;
 	}
 
 	/**
@@ -402,22 +327,19 @@ class WPMetaConfigs {
 	}
 
 	/**
-	 * Given a SimpleXMLElement, extracts the <TITLE> element and sets the title from that.
-	 * @param \SimpleXMLElement $html_file
-	 *
-	 * @return string
+	 * @param mixed $post_type
 	 */
-	private function getTitleFromTag( \SimpleXMLElement $html_file ) {
-		$title = '';
-		foreach ( $html_file->head->title as $titleElement ) {
-			$title = '' . $titleElement;
+	public function setPostType( $post_type ) {
+		if ( !is_string( $post_type ) && !is_null( $post_type ) ) {
+			throw new \InvalidArgumentException( "Post type must be a string or null." );
 		}
-
-		return $title;
+		// typical values 'post' | 'page' | 'link' | 'nav_menu_item' | custom post type
+		$this->post_type = $post_type;
 	}
 
 	/**
 	 * Builds meta data based on a loaded WebPage, and HtmlImportSettings from the plugin.
+	 *
 	 * @param admin\HtmlImportSettings $globalSettings
 	 * @param WebPage                  $webPage
 	 * @param null                     $post_id
@@ -434,7 +356,7 @@ class WPMetaConfigs {
 			$file_as_xml_obj = null;
 		} else {
 			$file_as_xml_obj = XMLHelper::getXMLObjectFromString( $webPage->getContent() );
-			if (!is_null($file_as_xml_obj)) {
+			if ( !is_null( $file_as_xml_obj ) ) {
 				$this->setPostContent( $file_as_xml_obj->body->asXML() );
 				$this->setPostTitle( $this->getTitleFromTag( $file_as_xml_obj ) );
 			}
@@ -484,6 +406,89 @@ class WPMetaConfigs {
 		$this->setPageTemplate( $globalSettings->getTemplate()->getValue() );
 
 
+	}
+
+	/**
+	 * Loads all of the meta data for a post given the post's ID.  Returns false of there is no post with that ID.
+	 *
+	 * @param $post_id
+	 *
+	 * @return bool
+	 */
+	public function loadFromPostID( $post_id ) {
+		$post_object = get_post( $post_id, 'OBJECT' );
+		if ( is_null( $post_object ) ) {
+			return false;
+		} else {
+			return $this->loadFromPostObject( $post_object );
+		}
+	}
+
+	/**
+	 * Loads all of the meta data give an WP_Post object.  If there is no object, returns null.
+	 *
+	 * @param \WP_Post $post
+	 *
+	 * @return bool
+	 */
+	public function loadFromPostObject( \WP_Post $post ) {
+		if ( is_null( $post ) ) {
+			return false;
+		}
+
+		$this->post_id     = $post->ID;
+		$this->post_author = $post->post_author;
+		$this->post_name   = $post->post_name;
+		$this->post_type   = $post->post_type;
+		$this->post_title  = $post->post_title;
+		$this->post_date   = $post->post_date;
+		// $post->post_date_gmt
+		$this->post_content   = $post->content;
+		$this->post_excerpt   = $post->post_excerpt;
+		$this->comment_status = $post->comment_status;
+		$this->ping_status    = $post->ping_status;
+		$this->post_status    = $post->post_status;
+		// $post->post_password
+		$this->post_parent = $post->post_parent;
+		// $post->post_modified
+		// $post->post_modified_gmt
+		// $post->comment_count
+		$this->menu_order = $post->menu_order;
+
+		return true;
+	}
+
+	/**
+	 * Given a SimpleXMLElement, extracts the <TITLE> element and sets the title from that.
+	 *
+	 * @param \SimpleXMLElement $html_file
+	 *
+	 * @return string
+	 */
+	private function getTitleFromTag( \SimpleXMLElement $html_file ) {
+		$title = '';
+		foreach ( $html_file->head->title as $titleElement ) {
+			$title = '' . $titleElement;
+		}
+
+		return $title;
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function getPostTitle() {
+		return $this->post_title;
+	}
+
+	/**
+	 * @param mixed $post_title
+	 */
+	public function setPostTitle( $post_title ) {
+		if ( !is_string( $post_title ) && !is_null( $post_title ) ) {
+			throw new \InvalidArgumentException( "Post title must be a string or null." );
+		}
+		$this->post_title = htmlspecialchars( $post_title );
 	}
 
 } 

--- a/public/includes/XMLHelper.php
+++ b/public/includes/XMLHelper.php
@@ -17,6 +17,7 @@ namespace html_import;
 class XMLHelper {
 	/**
 	 * Returns a SimpleXMLElement object given an XML contained in a string.
+	 *
 	 * @param $source_string
 	 *
 	 * @return \SimpleXMLElement
@@ -26,19 +27,21 @@ class XMLHelper {
 		$doc->strictErrorChecking = false;
 		libxml_use_internal_errors( true ); // some ok HTML will generate errors, this masks them, pt 1/2
 		$xmlValid = @$doc->loadHTML( $source_string/*, LIBXML_HTML_NOIMPLIED */ ); // server uses 5.3.28, this is added in 5.4
-		if ($xmlValid) {
+		if ( $xmlValid ) {
 			libxml_clear_errors(); // some ok HTML will generate errors, this masks them, pt 2/2
 			$file_as_xml_obj = simplexml_import_dom( $doc );
 
 			return $file_as_xml_obj;
 		} else {
 			echo 'Empty string used for XML source<br>';
+
 			return null;
 		}
 	}
 
 	/**
 	 * Returns a SimpleXMLElement object given a path to an XML file.
+	 *
 	 * @param $source_file
 	 *
 	 * @return \SimpleXMLElement
@@ -55,9 +58,32 @@ class XMLHelper {
 	}
 
 	// TODO: find an appropriate place for this
+
+	/**
+	 * Verifies that a file exists at the path provided, whether it's a URL or a local file.
+	 *
+	 * @param $xml_path
+	 *
+	 * @return bool|mixed
+	 */
+	public static function valid_xml_file( $xml_path ) {
+		if ( filter_var( $xml_path, FILTER_VALIDATE_URL ) ) { // if URL
+			return self::url_exists( $xml_path );
+		} else {
+			if ( file_exists( $xml_path ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	// TODO: this should be beefed up to actually validate that it's an XML
+
 	/**
 	 * Check to determine if the provided URL resolves to a real file.  Returns true if so, false otherwise.
 	 * source from: http://php.net/manual/en/function.file-exists.php
+	 *
 	 * @param $url
 	 *
 	 * @return mixed
@@ -79,27 +105,9 @@ class XMLHelper {
 		return $connectable;
 	}
 
-	// TODO: this should be beefed up to actually validate that it's an XML
-	/**
-	 * Verifies that a file exists at the path provided, whether it's a URL or a local file.
-	 * @param $xml_path
-	 *
-	 * @return bool|mixed
-	 */
-	public static function valid_xml_file( $xml_path ) {
-		if ( filter_var( $xml_path, FILTER_VALIDATE_URL ) ) { // if URL
-			return self::url_exists( $xml_path );
-		} else {
-			if ( file_exists( $xml_path ) ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
 	/**
 	 * Given an HTML file in a string, returns an array listing all of the URLs from the <a href>s.
+	 *
 	 * @param $contentAsXML
 	 *
 	 * @return array

--- a/public/includes/indices/FlareWebsiteIndex.php
+++ b/public/includes/indices/FlareWebsiteIndex.php
@@ -74,6 +74,46 @@ class FlareWebsiteIndex extends WebsiteIndex {
 	}
 
 	/**
+	 * Converts the contents of a Toc_Chunk file into an array
+	 * The file using the values:
+	 *  path
+	 *  i - id
+	 *  t - title
+	 *
+	 * @param string $tocChunkContents
+	 *
+	 * @return array
+	 */
+	private function getFlareFileList( $tocChunkContents ) {
+		$count   = null;
+		$matches = null;
+		preg_match( '/^define\((.*)\);$/', $tocChunkContents, $matches );
+
+		$returnValue = preg_replace( '/(\\w):([\{\[])/', '"$1":$2', $matches[1], - 1, $count );
+
+		$jsonString = str_replace( "'", "\"", $returnValue );
+
+		$jsonArray = json_decode( $jsonString, true );
+
+		$fileList = Array();
+		foreach ( $jsonArray as $path => $chunk ) {
+			$id    = $chunk['i'];
+			$title = $chunk['t'];
+			if ( sizeof( $id ) > 1 ) {
+				foreach ( $id as $key => $value ) {
+					$fileList[$value]['path']  = null;
+					$fileList[$value]['title'] = $title[$key];
+				}
+			} else {
+				$fileList[$id[0]]['path']  = $path;
+				$fileList[$id[0]]['title'] = $title[0];
+			}
+		}
+
+		return $fileList;
+	}
+
+	/**
 	 * Build a LinkedTree tree from the file ordering and the file listing derived from the Flare index files.
 	 * The HTML file information is stored in the payload of the LinkedTree with WebPage object representing the file.
 	 *
@@ -109,47 +149,6 @@ class FlareWebsiteIndex extends WebsiteIndex {
 		}
 
 		return $firstNode;
-	}
-
-
-	/**
-	 * Converts the contents of a Toc_Chunk file into an array
-	 * The file using the values:
-	 *  path
-	 * 	i - id
-	 * 	t - title
-	 *
-	 * @param string $tocChunkContents
-	 *
-	 * @return array
-	 */
-	private function getFlareFileList( $tocChunkContents ) {
-		$count   = null;
-		$matches = null;
-		preg_match( '/^define\((.*)\);$/', $tocChunkContents, $matches );
-
-		$returnValue = preg_replace( '/(\\w):([\{\[])/', '"$1":$2', $matches[1], - 1, $count );
-
-		$jsonString = str_replace( "'", "\"", $returnValue );
-
-		$jsonArray = json_decode( $jsonString, true );
-
-		$fileList = Array();
-		foreach ( $jsonArray as $path => $chunk ) {
-			$id    = $chunk['i'];
-			$title = $chunk['t'];
-			if ( sizeof( $id ) > 1 ) {
-				foreach ( $id as $key => $value ) {
-					$fileList[$value]['path']  = null;
-					$fileList[$value]['title'] = $title[$key];
-				}
-			} else {
-				$fileList[$id[0]]['path']  = $path;
-				$fileList[$id[0]]['title'] = $title[0];
-			}
-		}
-
-		return $fileList;
 	}
 
 }

--- a/public/includes/indices/WebPage.php
+++ b/public/includes/indices/WebPage.php
@@ -58,7 +58,7 @@ class WebPage extends LinkedTree {
 	 *
 	 * @param integer $wp_id
 	 */
-	public function setWPID($wp_id) {
+	public function setWPID( $wp_id ) {
 		$this->wp_id = $wp_id;
 	}
 
@@ -112,6 +112,7 @@ class WebPage extends LinkedTree {
 	 * Builds up and returns the full path of the webpage, using the retriever as the foundation
 	 *
 	 * @param string $relativePath
+	 *
 	 * @return string
 	 */
 	public function getFullPath( $relativePath = null ) {
@@ -134,6 +135,7 @@ class WebPage extends LinkedTree {
 		if ( !is_string( $relativePath ) ) {
 			throw new \InvalidArgumentException( "Relative path of webpage must be a string (may be empty)" );
 		}
+
 		return $this->retriever->retrieveFileContents( $relativePath, dirname( $this->relativePath ) );
 	}
 
@@ -169,7 +171,7 @@ class WebPage extends LinkedTree {
 			$content = $this->retriever->retrieveFileContents( $this->getRelativePath() );
 		}
 
-		return is_null( $content ) || strlen($content) <= 0;
+		return is_null( $content ) || strlen( $content ) <= 0;
 	}
 
 	/**

--- a/public/includes/indices/WebPageSettings.php
+++ b/public/includes/indices/WebPageSettings.php
@@ -57,9 +57,9 @@ private $postType;
 	 * @param Array $categoryIds
 	 */
 	public function setCategories( Array $categoryIds ) {
-		for ($i = 0; $i < sizeof($categoryIds); $i++ ) {
-			if (!is_string($categoryIds[$i])) {
-				throw new \InvalidArgumentException('Array $categoryIds must be all strings.');
+		for ( $i = 0; $i < sizeof( $categoryIds ); $i ++ ) {
+			if ( !is_string( $categoryIds[$i] ) ) {
+				throw new \InvalidArgumentException( 'Array $categoryIds must be all strings.' );
 			}
 		}
 		$this->categoryIds = $categoryIds;

--- a/public/includes/indices/WebsiteIndex.php
+++ b/public/includes/indices/WebsiteIndex.php
@@ -22,9 +22,8 @@ require_once( dirname( __FILE__ ) . '/../../../includes/LinkedTree.php' );
  */
 abstract class WebsiteIndex {
 	protected $retriever = null;
-	private $nodeCounter = - 1;
-	protected $trees = null; // This is an Array to store trees
-
+protected $trees = null;
+		private $nodeCounter = - 1; // This is an Array to store trees
 
 	/**
 	 * @param \droppedbars\files\FileRetriever $fileRetriever describes the source location of the index file(s)
@@ -52,6 +51,16 @@ abstract class WebsiteIndex {
 	 */
 	public function setToFirstFile() {
 		$this->nodeCounter = - 1;
+	}
+
+	/**
+	 * Return a LinkedTree node that contains the reference to the next HTML file indicated by the source index. If there is no next HTML file, return null.
+	 * @return \html_import\indices\WebPage|null the next HTML file
+	 */
+	public function getNextHTMLFile() {
+		$this->nodeCounter ++;
+
+		return $this->recurseTreeNodeForNext( null );
 	}
 
 	/**
@@ -96,15 +105,5 @@ abstract class WebsiteIndex {
 
 			return null;
 		}
-	}
-
-	/**
-	 * Return a LinkedTree node that contains the reference to the next HTML file indicated by the source index. If there is no next HTML file, return null.
-	 * @return \html_import\indices\WebPage|null the next HTML file
-	 */
-	public function getNextHTMLFile() {
-		$this->nodeCounter ++;
-
-		return $this->recurseTreeNodeForNext( null );
 	}
 }

--- a/public/includes/retriever/LocalAndURLAndURLFileRetriever.php
+++ b/public/includes/retriever/LocalAndURLAndURLFileRetriever.php
@@ -34,6 +34,33 @@ class LocalAndURLFileRetriever extends FileRetriever {
 	}
 
 	/**
+	 * Test to see if file exists, looking in the relativePath.  Return true if the file is there, false otherwise.
+	 *
+	 * @param string $file
+	 * @param string $relativePath
+	 *
+	 * @return bool
+	 */
+	public function fileExists( $file, $relativePath = '' ) {
+		$fullPath = $this->buildFullPath( $file, $relativePath );
+		if ( filter_var( $fullPath, FILTER_VALIDATE_URL ) ) { // if URL
+			if ( ( strpos( $fullPath, 'http://' ) == 0 ) || ( strpos( $fullPath, 'https://' ) == 0 ) ) {
+				$realPath = $fullPath;
+
+				return \html_import\XMLHelper::url_exists( $realPath );
+			} else {
+				echo '*** ' . $fullPath . ' is not an HTTP or HTTP URL.';
+
+				return null;
+			}
+		} else { // else if local directory
+			$realPath = realpath( $fullPath );
+
+			return file_exists( $realPath );
+		}
+	}
+
+	/**
 	 * Build up the full file path based on the file and relative path.
 	 *
 	 * @param $file
@@ -53,34 +80,6 @@ class LocalAndURLFileRetriever extends FileRetriever {
 		return $fullPath;
 	}
 
-
-
-	/**
-	 * Test to see if file exists, looking in the relativePath.  Return true if the file is there, false otherwise.
-	 *
-	 * @param string $file
-	 * @param string $relativePath
-	 *
-	 * @return bool
-	 */
-	public function fileExists( $file, $relativePath = '' ) {
-		$fullPath = $this->buildFullPath( $file, $relativePath );
-		if ( filter_var( $fullPath, FILTER_VALIDATE_URL ) ) { // if URL
-			if ((strpos($fullPath, 'http://') == 0) || (strpos($fullPath, 'https://') == 0)) {
-				$realPath = $fullPath;
-
-				return \html_import\XMLHelper::url_exists( $realPath );
-			} else {
-				echo '*** '. $fullPath .' is not an HTTP or HTTP URL.';
-				return null;
-			}
-		} else { // else if local directory
-			$realPath = realpath( $fullPath );
-
-			return file_exists( $realPath );
-		}
-	}
-
 	/**
 	 * Retrieve the contents file, if provided using the relativePath to the base path used for the class.
 	 * Returns the contents as as string.
@@ -94,7 +93,7 @@ class LocalAndURLFileRetriever extends FileRetriever {
 	public function retrieveFileContents( $file, $relativePath = '' ) {
 		$fullPath = $this->buildFullPath( $file, $relativePath );
 		if ( filter_var( $fullPath, FILTER_VALIDATE_URL ) ) { // if URL
-			if ((strpos($fullPath, 'http://') == 0) || (strpos($fullPath, 'https://') == 0)) {
+			if ( ( strpos( $fullPath, 'http://' ) == 0 ) || ( strpos( $fullPath, 'https://' ) == 0 ) ) {
 				$realPath = $fullPath;
 				if ( \html_import\XMLHelper::url_exists( $realPath ) ) {
 					$file_get_success = file_get_contents( $realPath );
@@ -109,15 +108,17 @@ class LocalAndURLFileRetriever extends FileRetriever {
 					return null;
 				}
 			} else {
-				echo '*** '. $fullPath .' is not an HTTP or HTTP URL.';
+				echo '*** ' . $fullPath . ' is not an HTTP or HTTP URL.';
+
 				return null;
 			}
 		} else { // else if local directory
 			$realPath = realpath( $fullPath );
 			if ( $realPath !== false ) {
 				$file_get_success = file_get_contents( $realPath );
-				if ($file_get_success === false) {
-					echo '*** '. $relativePath.' could not be read, may be non-existent or 0 length.';
+				if ( $file_get_success === false ) {
+					echo '*** ' . $relativePath . ' could not be read, may be non-existent or 0 length.';
+
 					return null;
 				} else {
 					return $file_get_success;
@@ -143,10 +144,11 @@ class LocalAndURLFileRetriever extends FileRetriever {
 		} else {
 			$fullPath = $this->buildFullPath( $file, $relativePath );
 			if ( filter_var( $fullPath, FILTER_VALIDATE_URL ) ) { // if URL
-				if ((strpos($fullPath, 'http://') == 0) || (strpos($fullPath, 'https://') == 0)) {
+				if ( ( strpos( $fullPath, 'http://' ) == 0 ) || ( strpos( $fullPath, 'https://' ) == 0 ) ) {
 					return $fullPath;
 				} else {
-					echo '*** '. $fullPath .' is not an HTTP or HTTP URL.';
+					echo '*** ' . $fullPath . ' is not an HTTP or HTTP URL.';
+
 					return null;
 				}
 			} else { // else if directory
@@ -168,13 +170,15 @@ class LocalAndURLFileRetriever extends FileRetriever {
 	 */
 	public function findFile( $filename, $relativePath = '' ) {
 		$fullPath = realpath( $this->localPath . '/' . $relativePath );
-		if (!$fullPath) {
-			echo 'Error trying to determine the realpath of '. $this->localPath.'/'.$relativePath.'<br>';
+		if ( !$fullPath ) {
+			echo 'Error trying to determine the realpath of ' . $this->localPath . '/' . $relativePath . '<br>';
+
 			return null;
 		}
 		$allFiles = @scandir( $fullPath );
-		if ($allFiles === false) {
-			echo 'Error trying to scan the directory: '. $fullPath.'.<br>';
+		if ( $allFiles === false ) {
+			echo 'Error trying to scan the directory: ' . $fullPath . '.<br>';
+
 			return null;
 		}
 		foreach ( $allFiles as $file ) {


### PR DESCRIPTION
Ensure code is formatted to Wordpress standard.
Allow PHPStorm to reposition code blocks.
Fix issue where clicking the link to show sample XML causes new window
to open.